### PR TITLE
Support <a> tag in items

### DIFF
--- a/paper-item.css
+++ b/paper-item.css
@@ -23,3 +23,11 @@
 #icon[hidden] {
   display: none;
 }
+
+::content > a {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}

--- a/paper-item.html
+++ b/paper-item.html
@@ -53,7 +53,7 @@ Example:
             var evt = document.createEvent('MouseEvents');
             evt.initMouseEvent('click', e.bubbles, e.cancelable, e.view,
                 e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
-                e.altKey, e.shiftKey, e.metaKey, e.button, link);
+                e.altKey, e.shiftKey, e.metaKey, e.button, null);
             link.dispatchEvent(evt, true);
           }
         });

--- a/paper-item.html
+++ b/paper-item.html
@@ -34,15 +34,30 @@ Example:
 
     <link href="paper-item.css" rel="stylesheet">
 
-    <paper-ripple id="ripple"></paper-ripple>
-
     <core-icon id="icon" hidden?="{{!iconSrc && !icon}}" src="{{iconSrc}}" icon="{{icon}}"></core-icon>
     {{label}}
     <content></content>
+
+    <paper-ripple id="ripple"></paper-ripple>
   </template>
 
   <script>
     Polymer('paper-item', {
+        
+      domReady: function () {
+        var that = this;
+        this.$.ripple.addEventListener('click', function (e) {
+          var link = that.querySelector('::content a');
+
+          if (link) {
+            var evt = document.createEvent('MouseEvents');
+            evt.initMouseEvent('click', e.bubbles, e.cancelable, e.view,
+                e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
+                e.altKey, e.shiftKey, e.metaKey, e.button, link);
+            link.dispatchEvent(evt, true);
+          }
+        });
+      },
 
       publish: {
 


### PR DESCRIPTION
The <core-item> tag supports an included <a> tag in the item. As far as I looked at it, it's just formatting the <a> tag to be position: absolute; and fit completely in the space taken by the item.

However in <paper-item> this is done with the <canvas> for the ripple effect, which makes laying the <a> over it impossible (would destroy the ripple effect). It should however be possible to handle the click event on one of those elements and pass it to the other, however we need to make sure that especially the position properties of that event are the same for the ripple center for example.

You think it'd be possible to solve that another way? Or do you not want to support <a> by default at all?
