### PR TITLE
Fix overescaping in <paper-item> docs

### DIFF
--- a/paper-item.html
+++ b/paper-item.html
@@ -21,7 +21,7 @@ Example:
         <paper-item label="Sign Out"></paper-item>
     </core-menu>
 
-To use as a link, put an `&lt;a&gt;` element in the item.
+To use as a link, put an `<a>` element in the item.
 
 Example:
 


### PR DESCRIPTION
http://www.polymer-project.org/docs/elements/paper-elements.html#paper-item currently says "To use as a link, put an &lt;a&gt; element in the item." I'm guessing this change will fix that. Hopefully it won't break anything else.
