### PR TITLE
Fix IE flex-basis rounding error.

### DIFF
--- a/paper-item.html
+++ b/paper-item.html
@@ -89,7 +89,7 @@ Example:
       ::content > a {
         height: 100%;
         /* flex */
-        -ms-flex: 1 1 0.000000001px;
+        -ms-flex: 1 1 auto;
         -webkit-flex: 1;
         flex: 1;
         -webkit-flex-basis: 0.000000001px;


### PR DESCRIPTION
IE 11 seems to round the 0.000000001px flex-basis value down to 0px, which causes content to overflow buttons, rather than the buttons fitting the content. Using a value of `auto` instead fixes this.
